### PR TITLE
Fixed field name typo in research importer

### DIFF
--- a/importers/research-importer.php
+++ b/importers/research-importer.php
@@ -162,10 +162,10 @@ Skipped  : {$this->researchers_skipped}
 				foreach( $researcher->education as $edu ) {
 					$educational_info[] = array(
 						'institution_name' => $edu->institution_name,
-						'role_name'       => $edu->role_name,
-						'start_date'      => $edu->start_date,
-						'end_date'        => $edu->end_date,
-						'department_date' => $edu->department_name
+						'role_name'        => $edu->role_name,
+						'start_date'       => $edu->start_date,
+						'end_date'         => $edu->end_date,
+						'department_date'  => $edu->department_name
 					);
 				}
 

--- a/importers/research-importer.php
+++ b/importers/research-importer.php
@@ -161,7 +161,7 @@ Skipped  : {$this->researchers_skipped}
 				// Capture all of the educational information
 				foreach( $researcher->education as $edu ) {
 					$educational_info[] = array(
-						'insitution_name' => $edu->institution_name,
+						'institution_name' => $edu->institution_name,
 						'role_name'       => $edu->role_name,
 						'start_date'      => $edu->start_date,
 						'end_date'        => $edu->end_date,


### PR DESCRIPTION
Renamed `insitution_name` field to `institution_name`.  Will put up a separate main site theme PR with the ACF config change shortly.