### PR TITLE
Researchers importer updates

### DIFF
--- a/importers/research-importer.php
+++ b/importers/research-importer.php
@@ -170,18 +170,9 @@ Deleted  : {$this->researchers_deleted}
 		 */
 		public function get_or_create_taxonomy_terms( $array, $taxonomy_name ) {
 			foreach( $array as $item ) {
-				$term_id = null;
-				$term_data = get_term_by( 'name', $item->name, $taxonomy_name, ARRAY_A );
+				$term_data = wp_create_term( $item->name, $taxonomy_name );
 
-				if ( ! $term_data ) {
-					$term_data = wp_insert_term( $item->name, $taxonomy_name );
-				}
-
-				if ( isset( $term_data['term_id'] ) ) {
-					$term_id = $term_data['term_id'];
-				}
-
-				return $term_id;
+				return $term_data['term_id'];
 			}
 		}
 

--- a/importers/research-importer.php
+++ b/importers/research-importer.php
@@ -230,7 +230,8 @@ Deleted  : {$this->researchers_deleted}
 				$trials      = array_map( array($this, 'get_simple_citation_html'), $trials_resp->results );
 
 				$post_meta = array(
-					'person_employee_id' => $researcher->teledata_record->employee_id,
+					'person_employee_id' => $researcher->employee_record->ext_employee_id,
+					'person_last_name'   => $researcher->employee_record->last_name,
 					'person_title'       => $researcher->teledata_record->job_position,
 					'person_email'       => $researcher->teledata_record->email,
 					'person_phone'       => $researcher->teledata_record->phone,

--- a/importers/research-importer.php
+++ b/importers/research-importer.php
@@ -197,6 +197,15 @@ Deleted  : {$this->researchers_deleted}
 
 				$this->post_ids_processed[] = $post_id;
 
+				// Capture all of the job titles
+				$job_titles = array();
+
+				foreach( $researcher->employee_record->job_titles as $job ) {
+					$job_titles[] = array(
+						'job_title' => $job->name
+					);
+				}
+
 				// Update the post meta
 				$educational_info = array();
 
@@ -232,7 +241,7 @@ Deleted  : {$this->researchers_deleted}
 				$post_meta = array(
 					'person_employee_id' => $researcher->employee_record->ext_employee_id,
 					'person_last_name'   => $researcher->employee_record->last_name,
-					'person_title'       => $researcher->teledata_record->job_position,
+					'person_titles'      => $job_titles,
 					'person_email'       => $researcher->teledata_record->email,
 					'person_phone'       => $researcher->teledata_record->phone,
 					'person_department'  => $researcher->teledata_record->dept->name,

--- a/importers/research-importer.php
+++ b/importers/research-importer.php
@@ -287,9 +287,13 @@ Deleted  : {$this->researchers_deleted}
 				}
 
 				// Assign departments
-				wp_set_post_terms( $post_id, array( $this->get_or_create_taxonomy_terms( $researcher->employee_record->departments, 'departments' ) ), 'departments' );
+				if ( $departments = $researcher->employee_record->departments ) {
+					wp_set_post_terms( $post_id, array( $this->get_or_create_taxonomy_terms( $departments, 'departments' ) ), 'departments' );
+				}
 				// Assign colleges
-				wp_set_post_terms( $post_id, array( $this->get_or_create_taxonomy_terms( $researcher->employee_record->colleges, 'colleges' ) ), 'colleges' );
+				if ( $colleges = $researcher->employee_record->colleges ) {
+					wp_set_post_terms( $post_id, array( $this->get_or_create_taxonomy_terms( $colleges, 'colleges' ) ), 'colleges' );
+				}
 
 				foreach( $post_meta as $key => $val ) {
 					\update_field( $key, $val, $post_id );

--- a/importers/research-importer.php
+++ b/importers/research-importer.php
@@ -170,7 +170,7 @@ Deleted  : {$this->researchers_deleted}
 			foreach( $this->researchers as $researcher ) {
 				$this->researchers_processed++;
 
-				$existing = $this->get_researcher_record( $researcher->teledata_record->employee_id );
+				$existing = $this->get_researcher_record( $researcher->employee_record->ext_employee_id );
 
 				$post_data = array(
 					'post_title'        => $researcher->name_formatted_title,
@@ -235,7 +235,6 @@ Deleted  : {$this->researchers_deleted}
 					'person_title'       => $researcher->teledata_record->job_position,
 					'person_email'       => $researcher->teledata_record->email,
 					'person_phone'       => $researcher->teledata_record->phone,
-					'person_office'      => "{$researcher->teledata_record->bldg->abbr} {$researcher->teledata_record->room}",
 					'person_department'  => $researcher->teledata_record->dept->name,
 					'person_degrees'     => $educational_info,
 					'person_books'       => $books,

--- a/includes/commands.php
+++ b/includes/commands.php
@@ -33,11 +33,11 @@ namespace UCF\MainSiteUtilities\Commands {
 		 */
 		public function import( $args, $assoc_args ) {
 			list( $search_url ) = $args;
-			$params = $assoc_args['additional-params'] ?? null;
+			$params = $assoc_args['params'] ?? null;
 			$force_template = filter_var( $assoc_args['force-template'] ?? false, FILTER_VALIDATE_BOOLEAN );
 			$force_update = filter_var( $assoc_args['force-update'] ?? false, FILTER_VALIDATE_BOOLEAN );
 
-			$importer = new Importers\ResearchImporter( $search_url, $params, $force_template );
+			$importer = new Importers\ResearchImporter( $search_url, $params, $force_template, $force_update );
 
 			try {
 				$importer->import();


### PR DESCRIPTION
**Adjustments:**
- Updates employee ID to point to new `employee_record` data
- Add `last_name` import
- Removes office & bldg information (per Roger, not necessary to display on faculty pages as of right now)
- Add functionality to create/assign terms for departments and colleges
- Imports all job titles into updated job title field (see Main-Site PR)
- Fix force-update and param args for the researcher import command

Resolves #13 