### PR TITLE
Create shortcode and functions for retrieving job listings from WorkDay

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Custom configuration settings
+ */
+
+namespace UCF\MainSiteUtilities\Includes\Config;
+
+
+define( 'UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX', defined( 'THEME_CUSTOMIZER_PREFIX' ) ? THEME_CUSTOMIZER_PREFIX : 'ucf_main_site_' );
+
+define( 'UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_DEFAULTS', serialize( array(
+	// TODO: These URLs will need to be updated once we have production URLs after July 1st
+	'jobs_base_url' => 'https://ucf4.wd2.myworkdayjobs-impl.com/en-US/careers',
+	'jobs_feed_url' => 'https://ucf4.wd2.myworkdayjobs-impl.com/wday/cxs/ucf4/careers/jobs/'
+) ) );
+
+
+/**
+ * Returns a plugin option's default value.
+ *
+ * @since 2.1.0
+ * @param string $option_name The name of the option
+ * @return mixed Option default value, or false if a default is not set
+ */
+function get_option_default( $option_name ) {
+	$defaults = unserialize( UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_DEFAULTS );
+	if ( $defaults && isset( $defaults[$option_name] ) ) {
+		return $defaults[$option_name];
+	}
+	return false;
+}
+
+
+/**
+ * Initialization functions to be fired early when WordPress loads the plugin.
+ *
+ * @since 2.1.0
+ * @return void
+ */
+function init() {
+	// Enforce default option values when `get_option()` is called.
+	$options = unserialize( UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_DEFAULTS );
+
+	foreach ( $options as $option_name => $option_default ) {
+		// Apply our plugin prefix to the option name:
+		$option_name = UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . $option_name;
+
+		// Enforce a default value for options we've defined defaults for:
+		add_filter( "default_option_$option_name", function( $get_option_default, $option, $passed_default ) use ( $option_default ) {
+			// If get_option() was passed a unique default value, prioritize it
+			if ( $passed_default ) {
+				return $get_option_default;
+			}
+			return $option_default;
+		}, 10, 3 );
+
+		// Enforce typecasting of returned option values,
+		// based on the types of the defaults we've defined.
+		// NOTE: Forces option defaults to return when empty
+		// option values are retrieved.
+		add_filter( "option_$option_name", function( $value, $option ) use ( $option_default ) {
+			switch ( $type = gettype( $option_default ) ) {
+				case 'integer':
+					// Assume 0 should be "empty" here:
+					$value = intval( $value );
+					break;
+				case 'string':
+				default:
+					break;
+			}
+
+			if ( empty( $value ) ) {
+				$value = $option_default;
+			}
+
+			return $value;
+		}, 10, 2 );
+	}
+}
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+
+/**
+ * Defines sections used in the WordPress Customizer.
+ *
+ * @since 2.1.0
+ * @author Cadie Stockman
+ */
+function define_customizer_sections( $wp_customize ) {
+	$wp_customize->add_section(
+		UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs',
+		array(
+			'title' => 'Jobs'
+		)
+	);
+}
+
+add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_sections' );
+
+
+/**
+ * Defines settings and controls used in the WordPress Customizer.
+ *
+ * @since 2.1.0
+ * @author Cadie Stockman
+ */
+function define_customizer_fields( $wp_customize ) {
+	$wp_customize->add_setting(
+		UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs_feed_url',
+		array(
+			'default' => get_option_default( 'jobs_feed_url' ),
+			'type'    => 'option'
+		)
+	);
+
+	$wp_customize->add_control(
+		UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs_feed_url',
+		array(
+			'type'        => 'url',
+			'label'       => 'Job Listing Feed URL',
+			'description' => 'URL to the JSON feed for UCF job listings.',
+			'section'     => UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs'
+		)
+	);
+
+	$wp_customize->add_setting(
+		UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs_base_url',
+		array(
+			'default' => get_option_default( 'jobs_base_url' ),
+			'type'    => 'option'
+		)
+	);
+
+	$wp_customize->add_control(
+		UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs_base_url',
+		array(
+			'type'        => 'url',
+			'label'       => 'Job Site Base URL',
+			'description' => 'URL for UCF\'s job site.',
+			'section'     => UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs'
+		)
+	);
+}
+
+add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_fields' );

--- a/includes/config.php
+++ b/includes/config.php
@@ -18,7 +18,7 @@ define( 'UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_DEFAULTS', serialize( array(
 /**
  * Returns a plugin option's default value.
  *
- * @since 2.1.0
+ * @since 3.0.0
  * @param string $option_name The name of the option
  * @return mixed Option default value, or false if a default is not set
  */
@@ -34,7 +34,7 @@ function get_option_default( $option_name ) {
 /**
  * Initialization functions to be fired early when WordPress loads the plugin.
  *
- * @since 2.1.0
+ * @since 3.0.0
  * @return void
  */
 function init() {
@@ -84,7 +84,7 @@ add_action( 'init', __NAMESPACE__ . '\init' );
 /**
  * Defines sections used in the WordPress Customizer.
  *
- * @since 2.1.0
+ * @since 3.0.0
  * @author Cadie Stockman
  */
 function define_customizer_sections( $wp_customize ) {
@@ -102,7 +102,7 @@ add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_sections' 
 /**
  * Defines settings and controls used in the WordPress Customizer.
  *
- * @since 2.1.0
+ * @since 3.0.0
  * @author Cadie Stockman
  */
 function define_customizer_fields( $wp_customize ) {

--- a/includes/ucf-jobs-feed.php
+++ b/includes/ucf-jobs-feed.php
@@ -9,7 +9,7 @@ namespace UCF\MainSiteUtilities\Feeds;
  * Retrieve the job listing data from the given feed url.
  *
  * @author Cadie Stockman
- * @since 2.1.0
+ * @since 3.0.0
  * @param array $args Arg array
  * @return object $result Job listings data
  **/

--- a/includes/ucf-jobs-feed.php
+++ b/includes/ucf-jobs-feed.php
@@ -11,7 +11,7 @@ namespace UCF\MainSiteUtilities\Feeds;
  * @author Cadie Stockman
  * @since 3.0.0
  * @param array $args Arg array
- * @return object $result Job listings data
+ * @return object|false $result Job listings object data or false if JSON data cannot be retrieved
  **/
 function retrieve_job_listing_data( $args ) {
 	$feed_url = get_option( UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs_feed_url' );
@@ -32,27 +32,8 @@ function retrieve_job_listing_data( $args ) {
 	$result        = false;
 
 	if ( is_array( $response ) && is_int( $response_code ) && $response_code < 400 ) {
-		$response_body = wp_remote_retrieve_body( $response );
-		$result = validate_json( $response_body ) ? json_decode( $response_body ) : false;
+		$result = json_decode( wp_remote_retrieve_body( $response ) );
 	}
 
-	return $result;
-}
-
-
-/**
- * Checks if the given string is valid JSON.
- *
- * @author Cadie Stockman
- * @since 3.0.0
- * @param string $str Given string
- * @return boolean Returns true if valid JSON.
- **/
-function validate_json( $str ) {
-	if ( is_string( $str ) ) {
-		json_decode( $str );
-		return ( json_last_error() === JSON_ERROR_NONE );
-	}
-
-	return false;
+	return ( ! is_null( $result ) ) ? $result : false;
 }

--- a/includes/ucf-jobs-feed.php
+++ b/includes/ucf-jobs-feed.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Handles all Jobs feed related code.
+ **/
+
+namespace UCF\MainSiteUtilities\Feeds;
+
+/**
+ * Retrieve the job listing data from the given feed url.
+ *
+ * @author Cadie Stockman
+ * @since 2.1.0
+ * @param array $args Arg array
+ * @return object $result Job listings data
+ **/
+function retrieve_job_listing_data( $args ) {
+	$feed_url = get_option( UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs_feed_url' );
+	$post_args = array(
+		'body' => wp_json_encode( array(
+			// 'appliedFacets' => {}, // TODO: Add feature for defining job type filters
+			'limit'      => $args['limit'],
+			'offset'     => $args['offset'],
+			'searchText' => ''
+		) ),
+		'headers' => array(
+			'content-type' => 'application/json'
+		)
+	);
+
+	$response      = wp_remote_post( $feed_url, $post_args );
+	$response_code = wp_remote_retrieve_response_code( $response );
+	$result        = false;
+
+	if ( is_array( $response ) && is_int( $response_code ) && $response_code < 400 ) {
+		$result = json_decode( wp_remote_retrieve_body( $response ) );
+	}
+
+	return $result;
+}

--- a/includes/ucf-jobs-feed.php
+++ b/includes/ucf-jobs-feed.php
@@ -32,8 +32,27 @@ function retrieve_job_listing_data( $args ) {
 	$result        = false;
 
 	if ( is_array( $response ) && is_int( $response_code ) && $response_code < 400 ) {
-		$result = json_decode( wp_remote_retrieve_body( $response ) );
+		$response_body = wp_remote_retrieve_body( $response );
+		$result = validate_json( $response_body ) ? json_decode( $response_body ) : false;
 	}
 
 	return $result;
+}
+
+
+/**
+ * Checks if the given string is valid JSON.
+ *
+ * @author Cadie Stockman
+ * @since 3.0.0
+ * @param string $str Given string
+ * @return boolean Returns true if valid JSON.
+ **/
+function validate_json( $str ) {
+	if ( is_string( $str ) ) {
+		json_decode( $str );
+		return ( json_last_error() === JSON_ERROR_NONE );
+	}
+
+	return false;
 }

--- a/includes/ucf-jobs-shortcode.php
+++ b/includes/ucf-jobs-shortcode.php
@@ -32,7 +32,8 @@ class Jobs_Shortcode {
 			'limit'  => 10,
 			'offset' => 0,
 			'ul_classes' => '',
-			'li_classes' => ''
+			'li_classes' => '',
+			'a_classes' => ''
 		), $attr );
 
 		$args = array(
@@ -45,7 +46,7 @@ class Jobs_Shortcode {
 		ob_start();
 
 		if ( $items !== null && $items->jobPostings ) {
-			echo Jobs_Shortcode::sc_ucf_jobs_display_jobs_list( $items->jobPostings, $attr['ul_classes'], $attr['li_classes'] );
+			echo Jobs_Shortcode::sc_ucf_jobs_display_jobs_list( $items->jobPostings, $attr['ul_classes'], $attr['li_classes'], $attr['a_classes'] );
 		} else {
 			echo 'No jobs listing data to display.';
 		}
@@ -59,11 +60,12 @@ class Jobs_Shortcode {
 	 *
 	 * @since 2.1.0
 	 * @param array $job_postings The array of job postings from the Jobs feed
-	 * @param string $ul_classes String of classes to be placed on the HTML ul tag
-	 * @param string $li_classes String of classes to be placed on the HTML li tags
+	 * @param string $ul_classes String of classes to be placed on the HTML <ul> tag
+	 * @param string $li_classes String of classes to be placed on the HTML <li> tags
+	 * @param string $a_classes String of classes to be placed on the HTML <a> tags
 	 * @return string HTML list markup
 	 **/
-	public static function sc_ucf_jobs_display_jobs_list( $job_postings, $ul_classes, $li_classes ) {
+	public static function sc_ucf_jobs_display_jobs_list( $job_postings, $ul_classes, $li_classes, $a_classes ) {
 		// var_dump( $job_postings );
 
 		ob_start();
@@ -81,7 +83,7 @@ class Jobs_Shortcode {
 			if ( $title && $url ) :
 	?>
 			<li <?php echo ( ! empty( $li_classes ) ) ? 'class="' . $li_classes . '"' : ''; ?>>
-				<a href="<?php echo $url; ?>"><?php echo $title; ?></a>
+				<a <?php echo ( ! empty( $a_classes ) ) ? 'class="' . $a_classes . '" ' : ''; ?>href="<?php echo $url; ?>"><?php echo $title; ?></a>
 			</li>
 
 	<?php

--- a/includes/ucf-jobs-shortcode.php
+++ b/includes/ucf-jobs-shortcode.php
@@ -25,7 +25,7 @@ class Jobs_Shortcode {
 	 * @since 3.0.0
 	 * @param array $attr The parsed attribute array
 	 * @param string $content Content passed into the shortcode
-	 * @return string
+	 * @return string HTML markup for displaying job listings
 	 */
 	public static function sc_ucf_jobs( $attr, $content='' ) {
 		$attr = shortcode_atts( array(
@@ -45,7 +45,7 @@ class Jobs_Shortcode {
 
 		ob_start();
 
-		if ( $items !== null && $items->jobPostings ) {
+		if ( $items && $items->jobPostings ) {
 			echo Jobs_Shortcode::sc_ucf_jobs_display_jobs_list( $items->jobPostings, $attr );
 		} else {
 			echo 'No job listings to display.';

--- a/includes/ucf-jobs-shortcode.php
+++ b/includes/ucf-jobs-shortcode.php
@@ -29,11 +29,11 @@ class Jobs_Shortcode {
 	 */
 	public static function sc_ucf_jobs( $attr, $content='' ) {
 		$attr = shortcode_atts( array(
-			'limit'  => 10,
-			'offset' => 0,
+			'limit'      => 10,
+			'offset'     => 0,
 			'ul_classes' => '',
 			'li_classes' => '',
-			'a_classes' => ''
+			'a_classes'  => ''
 		), $attr );
 
 		$args = array(

--- a/includes/ucf-jobs-shortcode.php
+++ b/includes/ucf-jobs-shortcode.php
@@ -48,7 +48,7 @@ class Jobs_Shortcode {
 		if ( $items !== null && $items->jobPostings ) {
 			echo Jobs_Shortcode::sc_ucf_jobs_display_jobs_list( $items->jobPostings, $attr );
 		} else {
-			echo 'No jobs listing data to display.';
+			echo 'No job listings to display.';
 		}
 
 		return ob_get_clean();

--- a/includes/ucf-jobs-shortcode.php
+++ b/includes/ucf-jobs-shortcode.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Handles the registration and display of the UCF Jobs Shortcode
+ **/
+
+namespace UCF\MainSiteUtilities\Shortcodes;
+
+use UCF\MainSiteUtilities\Feeds;
+
+class Jobs_Shortcode {
+	/**
+	 * Registers the `ucf-jobs` shortcode.
+	 *
+	 * @author Cadie Stockman
+	 * @since 2.1.0
+	 */
+	public static function register_shortcode() {
+		add_shortcode( 'ucf-jobs', array( __NAMESPACE__ . '\Jobs_Shortcode', 'sc_ucf_jobs' ) );
+	}
+
+	/**
+	 * Generates the `ucf-jobs` markup.
+	 *
+	 * @author Cadie Stockman
+	 * @since 2.1.0
+	 * @param array $attr The parsed attribute array
+	 * @param string $content Content passed into the shortcode
+	 * @return string
+	 */
+	public static function sc_ucf_jobs( $attr, $content='' ) {
+		$attr = shortcode_atts( array(
+			'limit'  => 10,
+			'offset' => 0,
+			'ul_classes' => '',
+			'li_classes' => ''
+		), $attr );
+
+		$args = array(
+			'limit'    => $attr['limit'] ? (int) $attr['limit'] : 10,
+			'offset'   => $attr['offset'] ? (int) $attr['offset'] : 0
+		);
+
+		$items = Feeds\retrieve_job_listing_data( $args );
+
+		ob_start();
+
+		if ( $items !== null && $items->jobPostings ) {
+			echo Jobs_Shortcode::sc_ucf_jobs_display_jobs_list( $items->jobPostings, $attr['ul_classes'], $attr['li_classes'] );
+		} else {
+			echo 'No jobs listing data to display.'
+		}
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Returns the HTML markup for the job postings
+	 * in an unordered list.
+	 *
+	 * @since 2.1.0
+	 * @param array $job_postings The array of job postings from the Jobs feed
+	 * @param string $ul_classes String of classes to be placed on the HTML ul tag
+	 * @param string $li_classes String of classes to be placed on the HTML li tags
+	 * @return string HTML list markup
+	 **/
+	public static function sc_ucf_jobs_display_jobs_list( $job_postings, $ul_classes, $li_classes ) {
+		// var_dump( $job_postings );
+
+		ob_start();
+
+		if ( is_array( $job_postings ) ) :
+	?>
+		<ul <?php echo ( ! empty( $ul_classes ) ) ? 'class="' . $ul_classes . '"' : ''; ?>>
+
+	<?php
+		foreach ( $job_postings as $job ) :
+			$title    = ! empty( $job->title ) ? $job->title : '';
+			$base_url = rtrim( get_option( UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs_base_url' ), "/" );
+			$url      = ! empty( $job->externalPath ) ? $base_url . $job->externalPath : '';
+
+			if ( $title && $url ) :
+	?>
+			<li <?php echo ( ! empty( $li_classes ) ) ? 'class="' . $li_classes . '"' : ''; ?>>
+				<a href="<?php echo $url; ?>"><?php echo $title; ?></a>
+			</li>
+
+	<?php
+			endif;
+
+		endforeach;
+	?>
+		</ul>
+
+	<?php
+		endif;
+
+		return ob_get_clean();
+	}
+}
+
+
+

--- a/includes/ucf-jobs-shortcode.php
+++ b/includes/ucf-jobs-shortcode.php
@@ -46,7 +46,7 @@ class Jobs_Shortcode {
 		ob_start();
 
 		if ( $items !== null && $items->jobPostings ) {
-			echo Jobs_Shortcode::sc_ucf_jobs_display_jobs_list( $items->jobPostings, $attr['ul_classes'], $attr['li_classes'], $attr['a_classes'] );
+			echo Jobs_Shortcode::sc_ucf_jobs_display_jobs_list( $items->jobPostings, $attr );
 		} else {
 			echo 'No jobs listing data to display.';
 		}
@@ -60,13 +60,13 @@ class Jobs_Shortcode {
 	 *
 	 * @since 2.1.0
 	 * @param array $job_postings The array of job postings from the Jobs feed
-	 * @param string $ul_classes String of classes to be placed on the HTML <ul> tag
-	 * @param string $li_classes String of classes to be placed on the HTML <li> tags
-	 * @param string $a_classes String of classes to be placed on the HTML <a> tags
+	 * @param array $attr Array of given shortcode attributes
 	 * @return string HTML list markup
 	 **/
-	public static function sc_ucf_jobs_display_jobs_list( $job_postings, $ul_classes, $li_classes, $a_classes ) {
-		// var_dump( $job_postings );
+	public static function sc_ucf_jobs_display_jobs_list( $job_postings, $attr ) {
+		$ul_classes = $attr['ul_classes'];
+		$li_classes = $attr['li_classes'];
+		$a_classes  = $attr['a_classes'];
 
 		ob_start();
 

--- a/includes/ucf-jobs-shortcode.php
+++ b/includes/ucf-jobs-shortcode.php
@@ -47,7 +47,7 @@ class Jobs_Shortcode {
 		if ( $items !== null && $items->jobPostings ) {
 			echo Jobs_Shortcode::sc_ucf_jobs_display_jobs_list( $items->jobPostings, $attr['ul_classes'], $attr['li_classes'] );
 		} else {
-			echo 'No jobs listing data to display.'
+			echo 'No jobs listing data to display.';
 		}
 
 		return ob_get_clean();

--- a/includes/ucf-jobs-shortcode.php
+++ b/includes/ucf-jobs-shortcode.php
@@ -12,7 +12,7 @@ class Jobs_Shortcode {
 	 * Registers the `ucf-jobs` shortcode.
 	 *
 	 * @author Cadie Stockman
-	 * @since 2.1.0
+	 * @since 3.0.0
 	 */
 	public static function register_shortcode() {
 		add_shortcode( 'ucf-jobs', array( __NAMESPACE__ . '\Jobs_Shortcode', 'sc_ucf_jobs' ) );
@@ -22,7 +22,7 @@ class Jobs_Shortcode {
 	 * Generates the `ucf-jobs` markup.
 	 *
 	 * @author Cadie Stockman
-	 * @since 2.1.0
+	 * @since 3.0.0
 	 * @param array $attr The parsed attribute array
 	 * @param string $content Content passed into the shortcode
 	 * @return string
@@ -58,7 +58,7 @@ class Jobs_Shortcode {
 	 * Returns the HTML markup for the job postings
 	 * in an unordered list.
 	 *
-	 * @since 2.1.0
+	 * @since 3.0.0
 	 * @param array $job_postings The array of job postings from the Jobs feed
 	 * @param array $attr Array of given shortcode attributes
 	 * @return string HTML list markup

--- a/main-site-utilities.php
+++ b/main-site-utilities.php
@@ -12,6 +12,9 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+define( 'UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+
+require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'includes/config.php';
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	// Pull in the degree importer files.
 	require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'importers/research-importer.php';

--- a/main-site-utilities.php
+++ b/main-site-utilities.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Main Site Utilities
 Description: Utility plugin for UCF's main site.
-Version: rc-2.1.0
+Version: rc-3.0.0
 Author: UCF Web Communications
 */
 

--- a/main-site-utilities.php
+++ b/main-site-utilities.php
@@ -28,6 +28,4 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	WP_CLI::add_command( 'research', 'UCF\MainSiteUtilities\Commands\ResearchCommands' );
 }
 
-add_action( 'plugins_loaded', function() {
-	add_action( 'init', array( __NAMESPACE__ . '\Shortcodes\Jobs_Shortcode', 'register_shortcode' ) );
-} );
+add_action( 'init', array( __NAMESPACE__ . '\Shortcodes\Jobs_Shortcode', 'register_shortcode' ) );

--- a/main-site-utilities.php
+++ b/main-site-utilities.php
@@ -1,15 +1,16 @@
 <?php
 /*
 Plugin Name: Main Site Utilities
-Version: 2.0.0
-Author: Jim Barnes
-Description: This is my plugin description.
+Description: Utility plugin for UCF's main site.
+Version: rc-2.1.0
+Author: UCF Web Communications
 */
-if ( ! defined( 'WPINC' ) ) {
-    die;
-}
 
-define( 'UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+namespace UCF\MainSiteUtilities;
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	// Pull in the degree importer files.

--- a/main-site-utilities.php
+++ b/main-site-utilities.php
@@ -15,6 +15,9 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'includes/config.php';
+require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'includes/ucf-jobs-feed.php';
+require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'includes/ucf-jobs-shortcode.php';
+
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	// Pull in the degree importer files.
 	require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'importers/research-importer.php';
@@ -24,3 +27,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 	WP_CLI::add_command( 'research', 'UCF\MainSiteUtilities\Commands\ResearchCommands' );
 }
+
+add_action( 'plugins_loaded', function() {
+	add_action( 'init', array( __NAMESPACE__ . '\Shortcodes\Jobs_Shortcode', 'register_shortcode' ) );
+} );


### PR DESCRIPTION
See title. 

Notes:
* This also changes the main plugin's file name from `commands.php` to `main-site-utilities.php`, which results in the plugin being deactivated if pushed when currently activated for the site. To go around this we can just deactivate it before we push up the changes to new environments. This shouldn't effect anything, since the only thing we use this plugin for currently is running WP-CLI commands. 
* New customizer options have been created for the Jobs/WorkDay URLs for the feed and the base site URL. The base URL is used to create the individual job listing links, since just the relative path to them is included in the json feed. The defaults set for them will need to be updated once we have the "live" WorkDay URLs come July 1.
* A future PR will add in the ability to filter listings by Job Family (faculty, staff, etc). 