### PR TITLE
changed the post method to get method and added the querystring

### DIFF
--- a/includes/ucf-jobs-feed.php
+++ b/includes/ucf-jobs-feed.php
@@ -19,10 +19,9 @@ function retrieve_job_listing_data( $args ) {
 	$feed_url = add_query_arg( array(
 		'limit'      => $args['limit'],
 		'offset'     => $args['offset'],
-		'searchText' => ''
 	), $feed_url );
 
-	$response = wp_remote_get($feed_url);
+	$response = wp_remote_get( $feed_url );
 	$response_code = wp_remote_retrieve_response_code( $response );
 	$result        = false;
 

--- a/includes/ucf-jobs-feed.php
+++ b/includes/ucf-jobs-feed.php
@@ -15,19 +15,14 @@ namespace UCF\MainSiteUtilities\Feeds;
  **/
 function retrieve_job_listing_data( $args ) {
 	$feed_url = get_option( UCF_MAIN_SITE_UTILITIES__CUSTOMIZER_PREFIX . 'jobs_feed_url' );
-	$post_args = array(
-		'body' => wp_json_encode( array(
-			// 'appliedFacets' => {}, // TODO: Add feature for defining job type filters
-			'limit'      => $args['limit'],
-			'offset'     => $args['offset'],
-			'searchText' => ''
-		) ),
-		'headers' => array(
-			'content-type' => 'application/json'
-		)
-	);
 
-	$response      = wp_remote_post( $feed_url, $post_args );
+	$feed_url = add_query_arg( array(
+		'limit'      => $args['limit'],
+		'offset'     => $args['offset'],
+		'searchText' => ''
+	), $feed_url );
+
+	$response = wp_remote_get($feed_url);
 	$response_code = wp_remote_retrieve_response_code( $response );
 	$result        = false;
 

--- a/includes/ucf-jobs-shortcode.php
+++ b/includes/ucf-jobs-shortcode.php
@@ -38,7 +38,7 @@ class Jobs_Shortcode {
 
 		$args = array(
 			'limit'    => $attr['limit'] ? (int) $attr['limit'] : 10,
-			'offset'   => $attr['offset'] ? (int) $attr['offset'] : 0
+			'offset'   => $attr['offset'] ? (int) $attr['offset'] : 0,
 		);
 
 		$items = Feeds\retrieve_job_listing_data( $args );


### PR DESCRIPTION
Since we don't want to update anything in the API, I changed wp_remote_post to wp_remote_get to limit the request. To include the offset and limit parameters, I appended them as a query string to the end of the URL. This allows me to receive these parameters in the Django application.

Tested on local and I was able to receive the limit + offset.  