### PR TITLE
Added converter for the new article template

### DIFF
--- a/importers/articles-converter.php
+++ b/importers/articles-converter.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Converts pages from the old article template to the new two-column article template.
+ */
+namespace UCF\MainSiteUtilities\Importers {
+
+	class ArticlesConverter {
+		private
+			$post_ids,
+			$dry_run,
+			$log = array(),
+
+			// Stats
+			$found     = 0,
+			$converted = 0;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param array $post_ids Optional list of post IDs to restrict conversion to.
+		 * @param bool  $dry_run  When true, no data is written.
+		 */
+		public function __construct( $post_ids = array(), $dry_run = false ) {
+			$this->post_ids = $post_ids;
+			$this->dry_run  = $dry_run;
+		}
+
+		/**
+		 * Runs the conversion.
+		 */
+		public function convert() {
+			$query_args = array(
+				'post_type'      => 'page',
+				'posts_per_page' => -1,
+				'post_status'    => 'any',
+				'meta_query'     => array(
+					array(
+						'key'   => '_wp_page_template',
+						'value' => 'template-article.php',
+					),
+				),
+			);
+
+			if ( ! empty( $this->post_ids ) ) {
+				$query_args['post__in'] = $this->post_ids;
+			}
+
+			$pages = get_posts( $query_args );
+
+			if ( empty( $pages ) ) {
+				$this->log[] = 'No pages found using template-article.php.';
+				return;
+			}
+
+			$this->found = count( $pages );
+			$this->log[] = sprintf( 'Found %d page(s) to convert.', $this->found );
+
+			foreach ( $pages as $page ) {
+				$this->log[] = sprintf( 'Processing: [%d] %s', $page->ID, $page->post_title );
+				$this->convert_page( $page );
+			}
+		}
+
+		/**
+		 * Converts a single page.
+		 *
+		 * @param \WP_Post $page
+		 */
+		private function convert_page( $page ) {
+			$sidebar_html = $this->build_sidebar_html( $page->ID );
+			$faqs         = $this->build_faqs( $page->ID );
+
+			if ( $this->dry_run ) {
+				$this->log[] = '  [dry-run] Would update _wp_page_template to template-article-two-col.php';
+
+				if ( $sidebar_html ) {
+					$this->log[] = sprintf( '  [dry-run] Would set sidebar_content (%d chars)', strlen( $sidebar_html ) );
+				} else {
+					$this->log[] = '  [dry-run] No sidebar fields to migrate.';
+				}
+
+				if ( $faqs ) {
+					$this->log[] = sprintf( '  [dry-run] Would convert %d personal_response row(s) to faqs.', count( $faqs ) );
+				} else {
+					$this->log[] = '  [dry-run] No personal_response data to migrate.';
+				}
+
+				$this->converted++;
+				return;
+			}
+
+			update_post_meta( $page->ID, '_wp_page_template', 'template-article-two-col.php' );
+
+			if ( $sidebar_html ) {
+				update_field( 'sidebar_content', $sidebar_html, $page->ID );
+			}
+
+			if ( $faqs ) {
+				update_field( 'faqs', $faqs, $page->ID );
+			}
+
+			$this->log[]  = '  Converted successfully.';
+			$this->converted++;
+		}
+
+		/**
+		 * Builds the sidebar HTML from the old template's repeater fields.
+		 *
+		 * Mirrors the markup from template-article.php so existing pages render
+		 * identically under the new template's sidebar_content WYSIWYG field.
+		 *
+		 * @param int $post_id
+		 * @return string
+		 */
+		private function build_sidebar_html( $post_id ) {
+			$html = '';
+
+			// Authors + References → "Researchers in Focus" card
+			$authors    = get_field( 'author', $post_id );
+			$references = get_field( 'references', $post_id );
+
+			if ( $authors || $references ) {
+				$html .= '<aside class="card bg-faded mb-4"><div class="card-block">';
+				$html .= '<h2 class="h4 heading-underline">Researchers in Focus</h2>';
+
+				if ( $authors ) {
+					$html .= '<h3 class="h6">Authors</h3>';
+					foreach ( $authors as $author ) {
+						$html .= '<div class="pl-2">';
+						$html .= '<p class="h6">' . esc_html( $author['name'] ) . '</p>';
+						$html .= '<p class="font-size-sm">' . wp_kses_post( $author['bio'] ) . '</p>';
+						$html .= '</div>';
+					}
+				}
+
+				if ( $references ) {
+					$html .= '<h3 class="h6">References</h3>';
+					$html .= '<ol class="references pl-4">';
+					foreach ( $references as $reference ) {
+						$html .= '<li class="list-item font-size-sm">' . wp_kses_post( $reference['reference'] ) . '</li>';
+					}
+					$html .= '</ol>';
+				}
+
+				$html .= '</div></aside>';
+			}
+
+			// Interview → separate cards for interviewees and interviewers
+			$interview = get_field( 'interview', $post_id );
+
+			if ( $interview ) {
+				$interviewees = array_filter( $interview, function( $person ) {
+					return $person['interviewer'] === false;
+				} );
+
+				$interviewers = array_filter( $interview, function( $person ) {
+					return $person['interviewer'] === true;
+				} );
+
+				if ( $interviewees ) {
+					$html .= '<aside class="card bg-faded mb-4"><div class="card-block">';
+					foreach ( $interviewees as $person ) {
+						$html .= '<div class="pl-2">';
+						$html .= '<p class="h4">' . esc_html( $person['name'] ) . '</p>';
+						$html .= '<p class="font-size-sm">' . wp_kses_post( $person['bio'] ) . '</p>';
+						$html .= '</div>';
+					}
+					$html .= '</div></aside>';
+				}
+
+				if ( $interviewers ) {
+					$html .= '<aside class="card bg-faded mb-4"><div class="card-block">';
+					$html .= '<h2 class="h4 heading-underline">Interviewers</h2>';
+					foreach ( $interviewers as $person ) {
+						$html .= '<div class="pl-2">';
+						$html .= '<p class="h6">' . esc_html( $person['name'] ) . '</p>';
+						$html .= '<p class="font-size-sm">' . wp_kses_post( $person['bio'] ) . '</p>';
+						$html .= '</div>';
+					}
+					$html .= '</div></aside>';
+				}
+			}
+
+			// Co-Authors card
+			$coauthors = get_field( 'co-authors', $post_id );
+
+			if ( $coauthors ) {
+				$html .= '<aside class="card bg-faded mb-4"><div class="card-block">';
+				$html .= '<h2 class="h4 heading-underline">Co-Authors</h2>';
+				$html .= '<ul class="list-unstyled">';
+				foreach ( $coauthors as $coauthor ) {
+					$html .= '<li class="list-item mb-4">' . wp_kses_post( $coauthor['co-author'] ) . '</li>';
+				}
+				$html .= '</ul>';
+				$html .= '</div></aside>';
+			}
+
+			// Related Programs card
+			$undergrad_programs = get_field( 'related_undergraduate_programs', $post_id );
+			$grad_programs      = get_field( 'related_graduate_programs', $post_id );
+
+			if ( $undergrad_programs || $grad_programs ) {
+				$html .= '<aside class="card bg-faded mb-4"><div class="card-block">';
+				$html .= '<h2 class="h4 heading-underline">Related Programs</h2>';
+
+				if ( $undergrad_programs ) {
+					$html .= '<h3 class="h6 text-uppercase">Undergraduate Programs</h3>';
+					$html .= '<ul class="list-unstyled pl-4">';
+					foreach ( $undergrad_programs as $program ) {
+						$html .= '<li class="list-item"><a href="' . esc_url( get_the_permalink( $program->ID ) ) . '">' . esc_html( $program->post_title ) . '</a></li>';
+					}
+					$html .= '</ul>';
+				}
+
+				if ( $grad_programs ) {
+					$html .= '<h3 class="h6 text-uppercase">Graduate Programs</h3>';
+					$html .= '<ul class="list-unstyled pl-4">';
+					foreach ( $grad_programs as $program ) {
+						$html .= '<li class="list-item"><a href="' . esc_url( get_the_permalink( $program->ID ) ) . '">' . esc_html( $program->post_title ) . '</a></li>';
+					}
+					$html .= '</ul>';
+				}
+
+				$html .= '</div></aside>';
+			}
+
+			return $html;
+		}
+
+		/**
+		 * Maps the old personal_response repeater to the new faqs repeater format.
+		 *
+		 * Both repeaters share the same question/answer subfield names, so this is
+		 * a direct structural mapping.
+		 *
+		 * @param int $post_id
+		 * @return array|null
+		 */
+		private function build_faqs( $post_id ) {
+			$personal_responses = get_field( 'personal_response', $post_id );
+
+			if ( empty( $personal_responses ) ) {
+				return null;
+			}
+
+			$faqs = array();
+			foreach ( $personal_responses as $response ) {
+				$faqs[] = array(
+					'question' => $response['question'],
+					'answer'   => $response['answer'],
+				);
+			}
+
+			return $faqs;
+		}
+
+		/**
+		 * Returns all log messages collected during conversion.
+		 *
+		 * @return array
+		 */
+		public function get_log() {
+			return $this->log;
+		}
+
+		/**
+		 * Returns a summary of conversion statistics.
+		 *
+		 * @return string
+		 */
+		public function get_stats() {
+			$label = $this->dry_run ? 'Would convert' : 'Converted';
+			return "
+Finished converting article pages!
+-----------------------------------
+Found    : {$this->found}
+{$label}: {$this->converted}
+			";
+		}
+	}
+}

--- a/includes/commands.php
+++ b/includes/commands.php
@@ -131,4 +131,54 @@ namespace UCF\MainSiteUtilities\Commands {
 			}
 		}
 	}
+
+	class ArticleCommands extends \WP_CLI_Command {
+
+		/**
+		 * Converts pages using the old "Area of Focus Article" template to the new
+		 * "Article (Two Column)" template.
+		 *
+		 * Sidebar repeater fields (authors, interview, co-authors, references, related
+		 * programs) are serialized into HTML and stored in the new `sidebar_content`
+		 * WYSIWYG field. The `personal_response` repeater is mapped to the new `faqs`
+		 * repeater. The `abstract` field is shared between both templates and requires
+		 * no migration.
+		 *
+		 * ## OPTIONS
+		 *
+		 * [--post-id=<id>]
+		 * : Convert only the page(s) with the specified post ID(s). Accepts a single ID or a comma-separated list (e.g. 123,456,789).
+		 *
+		 * [--dry-run]
+		 * : Preview changes without writing any data.
+		 *
+		 * ## EXAMPLES
+		 *
+		 *     wp article convert
+		 *     wp article convert --post-id=123
+		 *     wp article convert --post-id=123,456,789
+		 *     wp article convert --dry-run
+		 *
+		 * @when after_wp_load
+		 */
+		public function convert( $args, $assoc_args ) {
+			$dry_run  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+			$post_ids = array();
+
+			if ( isset( $assoc_args['post-id'] ) ) {
+				$post_ids = array_filter(
+					array_map( 'intval', explode( ',', $assoc_args['post-id'] ) )
+				);
+			}
+
+			$converter = new Importers\ArticlesConverter( $post_ids, $dry_run );
+			$converter->convert();
+
+			foreach ( $converter->get_log() as $message ) {
+				\WP_CLI::log( $message );
+			}
+
+			\WP_CLI::success( $converter->get_stats() );
+		}
+	}
 }

--- a/main-site-utilities.php
+++ b/main-site-utilities.php
@@ -24,10 +24,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'importers/research-media-importer.php';
 	require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'importers/research-media-csv-importer.php';
 	require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'importers/experts-importer.php';
+	require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'importers/articles-converter.php';
 	require_once UCF_MAIN_SITE_UTILITIES__PLUGIN_DIR . 'includes/commands.php';
 
 	\WP_CLI::add_command( 'research', 'UCF\MainSiteUtilities\Commands\ResearchCommands' );
 	\WP_CLI::add_command( 'expert', 'UCF\MainSiteUtilities\Commands\ExpertCommands' );
+	\WP_CLI::add_command( 'article', 'UCF\MainSiteUtilities\Commands\ArticleCommands' );
 }
 
 add_action( 'init', array( __NAMESPACE__ . '\Shortcodes\Jobs_Shortcode', 'register_shortcode' ) );


### PR DESCRIPTION
> [!NOTE]
> Most of the work on this branch, including this pull request description, was done by AI (GitHub Copilot).

## Add `wp article convert` WP CLI command

Adds a WP CLI command that migrates pages using the old `template-article.php` template to the new two-column `template-article-two-col.php` template introduced in the companion theme PR.

### What changed

#### New file: `importers/articles-converter.php`

Adds an `ArticlesConverter` class under the `UCF\MainSiteUtilities\Importers` namespace, following the same pattern as the existing `ResearchImporter` and `ExpertImporter` classes. The class handles all conversion logic:

- Queries all pages using `template-article.php` (optionally scoped to specific IDs)
- Updates `_wp_page_template` to `template-article-two-col.php`
- Reads the old ACF repeater/relationship fields and writes them into the new template's fields

#### Field mapping

| Old field(s) | New field | Notes |
|---|---|---|
| `author[]` (name, bio) + `references[]` | `sidebar_content` | Rendered as a "Researchers in Focus" card |
| `interview[]` (name, bio, interviewer flag) | `sidebar_content` | Interviewees and interviewers rendered as separate cards |
| `co-authors[]` | `sidebar_content` | Rendered as a "Co-Authors" card |
| `related_undergraduate_programs` + `related_graduate_programs` | `sidebar_content` | Rendered as a "Related Programs" card |
| `personal_response[]` (question, answer) | `faqs[]` (question, answer) | Remapped directly into the new FAQs repeater |
| `_wp_page_template` | `_wp_page_template` | `template-article.php` → `template-article-two-col.php` |

The `sidebar_content` HTML mirrors the markup from the old template so existing pages render identically under the new template.

#### Updated: `includes/commands.php`

Adds an `ArticleCommands` class (thin wrapper) that parses CLI arguments and delegates to `ArticlesConverter`.

**Usage:**
```sh
# Convert all article pages
wp article convert

# Dry run (no data written, logs what would change)
wp article convert --dry-run

# Convert specific page(s) by ID
wp article convert --post-id=2028
wp article convert --post-id=2028,2045,100021